### PR TITLE
Add Opera to the productivity section

### DIFF
--- a/productivity.section
+++ b/productivity.section
@@ -2,6 +2,7 @@ skype
 slack
 mailspring
 hiri
+opera
 wavebox
 onlyoffice-desktopeditors
 brave


### PR DESCRIPTION
Opera is not currently listed in any sections, they requested they be listed in the Productivity section. This pull request addresses that.