### PR TITLE
server section updates

### DIFF
--- a/server.section
+++ b/server.section
@@ -3,7 +3,6 @@ nextcloud
 wekan
 kata-containers
 docker
-google-cloud-sdk
 canonical-livepatch
 rocketchat-server
 mosquitto
@@ -13,14 +12,16 @@ stress-ng
 sabnzbd
 wormhole
 aws-cli
+azure-cli
+google-cloud-sdk
+slcli
 doctl
 conjure-up
 minidlna-escoand
 postgresql10
 heroku
 keepalived
-amazon-ssm-agent
 prometheus
 juju
-slcli
+
 


### PR DESCRIPTION
* do not offer amazon-ssm-agent, it only makes sense on EC2 instances
* add azure-cli, if we're offering cloud clis we may as well offer as many as we can
* group cloud cli snaps and alpha-sort them