### PR TITLE
remove amazon-ssm-agent and subiquity

### DIFF
--- a/server-and-cloud.section
+++ b/server-and-cloud.section
@@ -15,7 +15,6 @@ conjure-up
 minidlna-escoand
 heroku
 keepalived
-amazon-ssm-agent
 prometheus
 juju
 slcli
@@ -30,7 +29,6 @@ robomongo
 minikube
 mysql
 smonitor
-subiquity
 postgresql
 postgresql93
 postgresql94


### PR DESCRIPTION
We should definitely not be promoting the installation of these snaps on random machines!